### PR TITLE
implement security:check

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ with body-parameter apiCode=putSomethingUniqueHere
             "name": "Anchor",
             "isEnabled": true
         }
+    },
+    "security_check": {
+        "symfony/symfony": {
+            "version": "v3.4.12",
+            "advisories": {
+                "symfony/symfony/CVE-2018-14773.yaml": {
+                    "title": "CVE-2018-14773: Remove support for legacy and risky HTTP headers",
+                    "link": "https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers",
+                    "cve": "CVE-2018-14773"
+                }
+            }
+        }
     }
 }
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,20 +3,8 @@
 ***
 After every update you should check the pimcore extension manager. Just click the "update" button to finish the bundle update.
 
-#### Update from version 2.0.2 to version 2.0.3
-- updated upgrade notes
-
-#### Update from version 2.0.1 to version 2.0.2
-- **[BC BREAK]**
-    - changed request method from GET to POST
-    - changed request parameter from 'secret' to 'apiCode'
-    - changed configuration.yaml entry to 'api_code'
-- increased code consistency
-- implemented [PackageVersionTrait](https://github.com/pimcore/pimcore/blob/master/lib/Extension/Bundle/Traits/PackageVersionTrait.php)
-
 #### Update from version 2.0.0 to version 2.0.1
-- **[BC BREAK]** removed 'data' key from result-set
-- update of the readme
+- implemented Issue #1: Implement security:check
 
 #### Update to version 2.0.0 
 - Version 2.x is for Pimcore 5 (bundle), version 1.x is for Pimcore 4 (plugin)

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         }
     },
     "require": {
-        "pimcore/core-version": "^5.0.0"
+        "pimcore/core-version": "^5.0.0",
+        "sensiolabs/security-checker": "~3.0|~4.0"
     }
 }

--- a/src/MonitoringBundle/Controller/WatchDogController.php
+++ b/src/MonitoringBundle/Controller/WatchDogController.php
@@ -58,9 +58,10 @@ class WatchDogController extends FrontendController
         }
 
         return new JsonResponse([
-            'core'       => $this->watchDog->getCoreInfo(),
-            'extensions' => $this->watchDog->getExtensionsInfo(),
-            'bricks'     => $this->watchDog->getBricksInfo()
+            'core'           => $this->watchDog->getCoreInfo(),
+            'extensions'     => $this->watchDog->getExtensionsInfo(),
+            'bricks'         => $this->watchDog->getBricksInfo(),
+            'security_check' => $this->watchDog->getSecurityCheck()
         ], 200);
     }
 

--- a/src/MonitoringBundle/Service/WatchDog.php
+++ b/src/MonitoringBundle/Service/WatchDog.php
@@ -4,7 +4,9 @@ namespace MonitoringBundle\Service;
 
 use Pimcore\Extension\Bundle\PimcoreBundleManager;
 use Pimcore\Extension\Document\Areabrick\AreabrickManager;
+use Pimcore\Kernel;
 use Pimcore\Version;
+use SensioLabs\Security\SecurityChecker;
 
 /**
  * Class WatchDog
@@ -21,6 +23,14 @@ class WatchDog
      * @var AreabrickManager
      */
     protected $areabrickManager;
+    /**
+     * @var SecurityChecker
+     */
+    protected $securityChecker;
+    /**
+     * @var SymfonyKernel
+     */
+    protected $kernel;
 
     /**
      * WatchDog constructor.
@@ -30,10 +40,14 @@ class WatchDog
      */
     public function __construct(
         PimcoreBundleManager $pimcoreBundleManager,
-        AreabrickManager $areabrickManager
+        AreabrickManager $areabrickManager,
+        SecurityChecker $securityChecker,
+        Kernel $kernel
     ) {
         $this->pimcoreBundleManager = $pimcoreBundleManager;
         $this->areabrickManager = $areabrickManager;
+        $this->securityChecker = $securityChecker;
+        $this->kernel = $kernel;
     }
 
     /**
@@ -87,5 +101,13 @@ class WatchDog
         }
 
         return $extensions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSecurityCheck()
+    {
+        return $this->securityChecker->check($this->kernel->getProjectDir());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1 

implement security_check from symfony, resulting for example in something like this:
<pre>
    "security_check": {
        "symfony/symfony": {
            "version": "v3.4.12",
            "advisories": {
                "symfony/symfony/CVE-2018-14773.yaml": {
                    "title": "CVE-2018-14773: Remove support for legacy and risky HTTP headers",
                    "link": "https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers",
                    "cve": "CVE-2018-14773"
                }
            }
        }
    }
</pre>